### PR TITLE
Fix component-name-in-template-casing for v9

### DIFF
--- a/lib/rules/component-name-in-template-casing.js
+++ b/lib/rules/component-name-in-template-casing.js
@@ -67,9 +67,10 @@ module.exports = {
     /** @type {string[]} */
     const globals = (options.globals || []).map(casing.pascalCase)
     const registeredComponentsOnly = options.registeredComponentsOnly !== false
-    const tokens =
-      context.parserServices.getTemplateBodyTokenStore &&
-      context.parserServices.getTemplateBodyTokenStore()
+    const parserServices =
+      context.parserServices ||
+      context.sourceCode?.parserServices
+    const tokens = parserServices?.getTemplateBodyTokenStore?.()
 
     /** @type { Set<string> } */
     const registeredComponents = new Set(globals)


### PR DESCRIPTION
See https://github.com/rashfael/eslint-plugin-vue-pug/pull/26#issuecomment-2354871900