### PR TITLE
feat(config-name): differentiate configs added by vue-pug from ones added by vue

### DIFF
--- a/lib/configs/flat/vue2-essential.js
+++ b/lib/configs/flat/vue2-essential.js
@@ -9,7 +9,7 @@ const config = require('./base.js')
 module.exports = [
   ...config,
   {
-    name: 'vue/vue2-essential/rules',
+    name: 'vue-pug/vue2-essential/rules',
     rules: {
       'vue-pug/no-parsing-error': 'error'
     }

--- a/lib/configs/flat/vue2-recommended.js
+++ b/lib/configs/flat/vue2-recommended.js
@@ -9,7 +9,7 @@ const config = require('./vue2-strongly-recommended.js')
 module.exports = [
   ...config,
   {
-    name: 'vue/vue2-recommended/rules',
+    name: 'vue-pug/vue2-recommended/rules',
     rules: {}
   }
 ]

--- a/lib/configs/flat/vue2-strongly-recommended.js
+++ b/lib/configs/flat/vue2-strongly-recommended.js
@@ -9,7 +9,7 @@ const config = require('./vue2-essential.js')
 module.exports = [
   ...config,
   {
-    name: 'vue/vue2-strongly-recommended/rules',
+    name: 'vue-pug/vue2-strongly-recommended/rules',
     rules: {
       'vue-pug/no-pug-control-flow': 'warn'
     }

--- a/lib/configs/flat/vue3-essential.js
+++ b/lib/configs/flat/vue3-essential.js
@@ -9,7 +9,7 @@ const config = require('./base.js')
 module.exports = [
   ...config,
   {
-    name: 'vue/essential/rules',
+    name: 'vue-pug/essential/rules',
     rules: {
       'vue-pug/no-parsing-error': 'error'
     }

--- a/lib/configs/flat/vue3-recommended.js
+++ b/lib/configs/flat/vue3-recommended.js
@@ -9,7 +9,7 @@ const config = require('./vue3-strongly-recommended.js')
 module.exports = [
   ...config,
   {
-    name: 'vue/recommended/rules',
+    name: 'vue-pug/recommended/rules',
     rules: {}
   }
 ]

--- a/lib/configs/flat/vue3-strongly-recommended.js
+++ b/lib/configs/flat/vue3-strongly-recommended.js
@@ -9,7 +9,7 @@ const config = require('./vue3-essential.js')
 module.exports = [
   ...config,
   {
-    name: 'vue/strongly-recommended/rules',
+    name: 'vue-pug/strongly-recommended/rules',
     rules: {
       'vue-pug/no-pug-control-flow': 'warn'
     }

--- a/tools/update-lib-flat-configs.js
+++ b/tools/update-lib-flat-configs.js
@@ -112,7 +112,7 @@ const config = require('./${extendsCategoryId}.js')
 module.exports = [
   ...config,
   {
-    name: 'vue/${category.categoryId.replace(/^vue3-/u, '')}/rules',
+    name: 'vue-pug/${category.categoryId.replace(/^vue3-/u, '')}/rules',
     rules: ${formatRules(category.rules, category.categoryId)},
   }
 ]


### PR DESCRIPTION
Howdy!

Thanks for your work on this plugin, I love Pug and being able to apply eslint rules to it (especially attribute-order) is magic!

That said, while I was inspecting my config with `@eslint/config-inspector` I was confused by what looked to be repeated `vue/essential/rules` blocks (pictured below)
<img width="344" height="504" alt="a portion of the config highlighting the issue" src="https://github.com/user-attachments/assets/21c3e8fc-f254-4f62-a849-d74632ec3023" />

I'm not sure if there's an intentional reason for retaining the name or of it just got overlooked. Either way I figure I'd make a PR, cheers! 